### PR TITLE
specify mpi variants conda_build_config.yaml

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,3 @@
+mpi:
+  - openmpi
+  - mpich


### PR DESCRIPTION
needed for rerender to get the mpi variants. Maybe #14 had this file but forgot to commit it?

Otherwise, rerender fails with:

```
  File "~/conda/lib/python3.6/site-packages/conda_build/utils.py", line 1574, in <listcomp>
    matches = [regex.match(pkg) for pkg in reqs]
TypeError: expected string or bytes-like object
```

because `{{ mpi }}` is None.